### PR TITLE
Add support for unkown status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,17 @@ Additionally you can activate simplecov code coverage analysis for specs by sett
 $> COVERAGE=true rake spec
 ```
 
+If you get error: `'start_tcp_server': no acceptor (port is in use or requires root privileges) (RuntimeError)`
+make sure you aliased 127.0.0.2, 127.0.0.10 and 127.0.0.11 to 127.0.0.1.
+
+On OS X you can do it by executing following commands:
+
+```
+sudo ifconfig lo0 alias 127.0.0.2 up
+sudo ifconfig lo0 alias 127.0.0.10 up
+sudo ifconfig lo0 alias 127.0.0.11 up
+```
+
 ## Additional Information
 
 + [em-proxy](https://github.com/igrigorik/em-proxy)

--- a/lib/experella-proxy/http_status_codes.rb
+++ b/lib/experella-proxy/http_status_codes.rb
@@ -34,11 +34,13 @@ module ExperellaProxy
     413 => 'Request Entity Too Large',
     414 => 'Request-URI Too Large',
     415 => 'Unsupported Media Type',
+    422 => 'Unprocessable Entity',
     500 => 'Internal Server Error',
     501 => 'Not Implemented',
     502 => 'Bad Gateway',
     503 => 'Service Unavailable',
     504 => 'Gateway Time-out',
-    505 => 'HTTP Version not supported'
+    505 => 'HTTP Version not supported',
+    522 => 'Uknown Error'
   }
 end

--- a/lib/experella-proxy/response.rb
+++ b/lib/experella-proxy/response.rb
@@ -81,7 +81,7 @@ module ExperellaProxy
       # start line
       @send_buffer << "HTTP/1.1 "
       @send_buffer << @status_code.to_s + ' '
-      @send_buffer << HTTP_STATUS_CODES[@status_code] + "\r\n"
+      @send_buffer << HTTP_STATUS_CODES.fetch(@status_code, "") + "\r\n"
       # header fields
       @header.each do |key, value|
         key_val = key.to_s + ": "

--- a/lib/experella-proxy/response.rb
+++ b/lib/experella-proxy/response.rb
@@ -81,7 +81,7 @@ module ExperellaProxy
       # start line
       @send_buffer << "HTTP/1.1 "
       @send_buffer << @status_code.to_s + ' '
-      @send_buffer << HTTP_STATUS_CODES.fetch(@status_code, "") + "\r\n"
+      @send_buffer << HTTP_STATUS_CODES.fetch(@status_code, "Status-Code unknown to experella") + "\r\n"
       # header fields
       @header.each do |key, value|
         key_val = key.to_s + ": "

--- a/spec/experella-proxy/response_spec.rb
+++ b/spec/experella-proxy/response_spec.rb
@@ -62,7 +62,7 @@ describe ExperellaProxy::Response do
                                :"Via-X"     => %w(Lukas Amy George))
         response.reconstruct_header
         data = response.flush
-        data.start_with?("HTTP/1.1 99 \r\n").should be_true
+        data.start_with?("HTTP/1.1 99 Status-Code unknown to experella\r\n").should be_true
       end
     end
   end

--- a/spec/experella-proxy/response_spec.rb
+++ b/spec/experella-proxy/response_spec.rb
@@ -54,6 +54,17 @@ describe ExperellaProxy::Response do
       data.should include("Via-X: George\r\n")
       data.end_with?("\r\n\r\n").should be_true
     end
+
+    context "when status code does not exist in HTTP_STATUS_CODES" do
+      it "returns Uknown Error" do
+        response.instance_variable_set(:@status_code, 99)
+        response.update_header("Connection" => "keep-alive",
+                               :"Via-X"     => %w(Lukas Amy George))
+        response.reconstruct_header
+        data = response.flush
+        data.start_with?("HTTP/1.1 99 \r\n").should be_true
+      end
+    end
   end
 
 


### PR DESCRIPTION
Hi,
I would like to add support for `422` status code - quite popular amongst Rails backend for marking invalid objects.

I've also added fallback to empty string if status code doesn't exist in the `HTTP_STATUS_CODES` table - otherwise the whole proxy crashes with error: `undefined '+' for nil:NilClass`. I'm not sure if empty string is the best solution, any ideas?

I've also added small update to `Readme` with tips for setting up local test env.
